### PR TITLE
Add Possiblity to Animate Decreasing Progress

### DIFF
--- a/ESArcProgressView/ESArcProgressView+Animations.m
+++ b/ESArcProgressView/ESArcProgressView+Animations.m
@@ -65,7 +65,10 @@ static char kUpdateHandlerKey;
     CGFloat toValue = [timer.userInfo[@"to"] floatValue];
     NSTimeInterval duration = [timer.userInfo[@"duration"] doubleValue];
 
-    CGFloat percPercStep = (toValue - fromValue) / (duration * kFPS);
+    CGFloat percPercStep;
+    if (toValue >= fromValue) { percPercStep = toValue - fromValue; }
+    else { percPercStep = fromValue - toValue; }
+    percPercStep /= (duration * kFPS);
     NSInteger animationStep = [objc_getAssociatedObject(self, &kAnimationStepKey) integerValue];
     animationStep++;
     objc_setAssociatedObject(self, &kAnimationStepKey, @(animationStep), OBJC_ASSOCIATION_RETAIN_NONATOMIC);

--- a/ESArcProgressView/ESArcProgressView+Animations.m
+++ b/ESArcProgressView/ESArcProgressView+Animations.m
@@ -65,10 +65,7 @@ static char kUpdateHandlerKey;
     CGFloat toValue = [timer.userInfo[@"to"] floatValue];
     NSTimeInterval duration = [timer.userInfo[@"duration"] doubleValue];
 
-    CGFloat percPercStep;
-    if (toValue >= fromValue) { percPercStep = toValue - fromValue; }
-    else { percPercStep = fromValue - toValue; }
-    percPercStep /= (duration * kFPS);
+    CGFloat percPercStep = (toValue >= fromValue ? (toValue - fromValue) : (fromValue - toValue))/(duration * kFPS);
     NSInteger animationStep = [objc_getAssociatedObject(self, &kAnimationStepKey) integerValue];
     animationStep++;
     objc_setAssociatedObject(self, &kAnimationStepKey, @(animationStep), OBJC_ASSOCIATION_RETAIN_NONATOMIC);


### PR DESCRIPTION
If the progress start value (e.g. 1.0) is bigger than the progress final value (e.g. 0.5), the progress view would animate in the wrong direction (increasing, not decreasing).
This patch provides the ability to animate a decreasing progress.
