### PR TITLE
Fix CGPath leaks

### DIFF
--- a/ESArcProgressView/ESArcProgressViewCore.m
+++ b/ESArcProgressView/ESArcProgressViewCore.m
@@ -156,6 +156,7 @@
     CGPathAddRelativeArc(path, NULL, center.x, center.y, innerRadius, -(M_PI / 2), M_PI * 2);
     CGContextAddPath(ctx, path);
     CGContextStrokePath(ctx);
+    CGPathRelease(path);
     if (perc > 0) {
         
         CGContextSaveGState(ctx);
@@ -166,6 +167,7 @@
         CGContextAddPath(ctx, path);
         CGContextClosePath(ctx);
         CGContextEOClip(ctx);
+        CGPathRelease(path);
         
         // Shadow
         if (self.shouldShowShadow) {
@@ -179,6 +181,7 @@
         CGContextAddPath(ctx, path);
         CGContextStrokePath(ctx);
         CGContextRestoreGState(ctx);
+        CGPathRelease(path);
     }
     
     


### PR DESCRIPTION
When a `CGPath` is created with `CGPathCreateMutable`, it has a +1 retain count. 

[According to Apple](https://developer.apple.com/library/mac/qa/qa1565/_index.html), 

> ARC does not apply to Core Foundation types

While many Core Foundation objects can be "bridged" into ARC, in this case it seemed simpler to introduce the manual release commands. The above-linked Technical Q&A also clearly shows this applies to CoreGraphics types. All the other CG types used in the progress view are obtained such that their retain count is 0.
